### PR TITLE
Use new api for :crypto from OTP 24

### DIFF
--- a/lib/json_web_token_vivox/algorithm/hmac.ex
+++ b/lib/json_web_token_vivox/algorithm/hmac.ex
@@ -18,7 +18,7 @@ defmodule JsonWebTokenVivox.Algorithm.Hmac do
   """
   def sign(sha_bits, shared_key, signing_input) do
     validate_params(sha_bits, shared_key)
-    :crypto.hmac(sha_bits, shared_key, signing_input)
+    :crypto.mac(:hmac, sha_bits, shared_key, signing_input)
   end
 
   @doc """


### PR DESCRIPTION
Old :crypto.hmac/3 was removed in OTP 24 in favor of :crypto.mac/4.